### PR TITLE
(fix) Remove bootstrap from extension. Style control buttons manually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,89 @@
 
 Annotate the web.
 
-## Getting Started 
 
-1. Clone repo
-2. `npm install`
-3. Copy `.env.example` to `.env` and set any API keys or config variables in this file.
-4. `npm start`
 
-Now, navigate to `http://localhost:3000` to view the application.
+## Development Workflow
 
-## Commands
+### Step 0
 
-### `npm run clean`
+```
+$ git clone [this repo]
+$ npm install
+```
 
-Remove the `build/` directory.
+### Step 1
 
-### `npm run build`
+Read [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Build client side code to `build/` - one time.
+### Step 2 
 
-### `npm run watch`
+1. Install [Postgres DB]()
+1. Start Postgres DB
+1. Run `npm run create`
 
-Build and watch for changes to client side files. Recompile when files change.
+### Step 3
 
-### `npm start`
+Copy `.env.example` to `.env` and set any API keys or config variables in this file.
 
-Starts the express web server.
+### Step 4
 
-> If you issue `npm install -g nodemon`, you can type: `nodemon npm start` for development. 
+Open 4 terminals and do the following.
 
-### `npm test`
+|Terminal No.|Endpoint|
+|---|---|
+| 1 | `npm run watch-app` |
+| 2 | `npm run watch-ext` |
+| 3 | `npm run watch-athena` |
+| 4 | `npm start` |
 
-Run all tests. 
+### Step 5
+
+Load the extension found at `build/extension` into Chrome. (Ensure *Developer Mode* is checked)
+
+> **Each time you make a change to the extension source, you must reload the compiled code in Chrome**
+
+### Step 6
+
+Navigate to `http://localhost:3000` to view the Web App. 
+
+## Design
+
+There are 5 parts to the application:
+
+1. [The server](#the-server)
+1. [The web app](#the-web-app)
+1. [The extension](#the-chrome-extension)
+1. [The annotation engine](#the-annotation-engine)
+1. [Postgres](#postgres)
+
+### The Server
+
+To start the server, issue:
+
+```
+$ npm start
+```
+This starts an express server defaulted to `http://localhost:3000`. 
+
+#### Endpoints
+
+|Description|Endpoint|
+|---|---|
+|[Web App](#the-web-app)|GET /|
+|[Annotation iFrame](#the-annotation-iframe)|GET /athena/athena.html|
+|[Annotation Engine](#the-annotation-engine)|GET /athena/athena.js|
+
+### The Web App
+
+### The Chrome Extension
+
+### The Annotation Engine
+
+### Postgres DB
+
+1. Install
+1. Start
+1. `npm run create`
+
+

--- a/src/libs/athena/src/components/AnnotatePanel.js
+++ b/src/libs/athena/src/components/AnnotatePanel.js
@@ -4,7 +4,6 @@ import {
   FormGroup,
   ControlLabel,
   FormControl,
-  HelpBlock,
 } from 'react-bootstrap';
 import { saveAnnote } from '../utils/annotation';
 import FacebookLogout from './FacebookLogout';

--- a/src/libs/extension/content/src/assets/styles/app/_controls.scss
+++ b/src/libs/extension/content/src/assets/styles/app/_controls.scss
@@ -7,3 +7,118 @@
     visibility: hidden;
   }
 }
+
+.control-btn {
+  display: inline-block;
+  padding: 6px 12px;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1.42857143;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  -ms-touch-action: manipulation;
+      touch-action: manipulation;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+.control-btn:focus,
+.control-btn:active:focus,
+.control-btn.active:focus,
+.control-btn.focus,
+.control-btn:active.focus,
+.control-btn.active.focus {
+  outline: thin dotted;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+.control-btn:hover,
+.control-btn:focus,
+.control-btn.focus {
+  color: #333;
+  text-decoration: none;
+}
+.control-btn:active,
+.control-btn.active {
+  background-image: none;
+  outline: 0;
+  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
+          box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
+}
+.control-btn.disabled,
+.control-btn[disabled],
+fieldset[disabled] .control-btn {
+  cursor: not-allowed;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  opacity: .65;
+}
+a.control-btn.disabled,
+fieldset[disabled] a.control-btn {
+  pointer-events: none;
+}
+.control-btn-default {
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+.control-btn-default:focus,
+.control-btn-default.focus {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #8c8c8c;
+}
+.control-btn-default:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+.control-btn-default:active,
+.control-btn-default.active,
+.open > .dropdown-toggle.control-btn-default {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+.control-btn-default:active:hover,
+.control-btn-default.active:hover,
+.open > .dropdown-toggle.control-btn-default:hover,
+.control-btn-default:active:focus,
+.control-btn-default.active:focus,
+.open > .dropdown-toggle.control-btn-default:focus,
+.control-btn-default:active.focus,
+.control-btn-default.active.focus,
+.open > .dropdown-toggle.control-btn-default.focus {
+  color: #333;
+  background-color: #d4d4d4;
+  border-color: #8c8c8c;
+}
+.control-btn-default:active,
+.control-btn-default.active,
+.open > .dropdown-toggle.control-btn-default {
+  background-image: none;
+}
+.control-btn-default.disabled:hover,
+.control-btn-default[disabled]:hover,
+fieldset[disabled] .control-btn-default:hover,
+.control-btn-default.disabled:focus,
+.control-btn-default[disabled]:focus,
+fieldset[disabled] .control-btn-default:focus,
+.control-btn-default.disabled.focus,
+.control-btn-default[disabled].focus,
+fieldset[disabled] .control-btn-default.focus {
+  background-color: #fff;
+  border-color: #ccc;
+}
+.control-btn-default .badge {
+  color: #fff;
+  background-color: #333;
+}

--- a/src/libs/extension/content/src/components/ControlButton.js
+++ b/src/libs/extension/content/src/components/ControlButton.js
@@ -1,9 +1,8 @@
 import React, { PropTypes } from 'react';
-import { Button } from 'react-bootstrap';
 
 const ControlButton = ({ handler, label }) => (
   <span>
-    <Button onClick={handler}> {label} </Button>
+    <button className="control-btn control-btn-default" onClick={handler}> {label} </button>
   </span>
 );
 

--- a/src/libs/extension/content/src/index.js
+++ b/src/libs/extension/content/src/index.js
@@ -1,5 +1,3 @@
-import '../../../../../node_modules/bootstrap/dist/css/bootstrap.min.css';
-import '../../../../../node_modules/bootstrap/dist/css/bootstrap-theme.min.css';
 import './assets/styles/styles.scss';
 import React from 'react';
 import { render } from 'react-dom';
@@ -22,7 +20,6 @@ iframe.classList.add(HIDE_IFRAME_CLASS);
 document.body.appendChild(iframe);
 document.body.insertBefore(app, document.body.childNodes[0]);
 
-// @TODO: pass iframe into App
 render(
   <App iframe={iframe} />,
   document.getElementById('app-anchor')


### PR DESCRIPTION
Here's a small PR!
- removed bootstrap from extension react app
- control buttons are now styled by sass files (using bootstrap code), but name-spaced
